### PR TITLE
Patch to fix 1 basic management related failures and one general file…

### DIFF
--- a/src/librygel-core/rygel-basic-management.vala
+++ b/src/librygel-core/rygel-basic-management.vala
@@ -116,15 +116,18 @@ public class Rygel.BasicManagement : Service {
             this.tests_map[old_id].cancellable.cancel ();
             this.tests_map.unset (old_id);
         }
-        Thread.usleep(1000000);
-        this.freeze_notify();
-        this.notify ("TestIDs",
+
+        Timeout.add_seconds (1, () => {
+            notify ("TestIDs",
                      typeof (string),
                      create_test_ids_list (false),
                      "ActiveTestIDs",
                      typeof (string),
                      create_test_ids_list (true));
-        this.thaw_notify ();
+
+            return false;
+        });
+
         return test.id;
     }
 
@@ -136,13 +139,16 @@ public class Rygel.BasicManagement : Service {
          * practically required. */
         bm_test.run.begin ((obj,res) => {
             bm_test.run.end (res);
-            this.freeze_notify();
             bm_test.execution_state = BasicManagementTest.ExecutionState.COMPLETED;
-            Thread.usleep(1000000);
-            this.notify ("ActiveTestIDs",
-                         typeof (string),
-                         create_test_ids_list (true));
-            this.thaw_notify ();
+
+            Timeout.add_seconds (1, () => {
+                notify ("ActiveTestIDs",
+                             typeof (string),
+                             create_test_ids_list (true));
+
+                return false;
+            });
+
         });
 
         action.set ("TestID", typeof (string), id);


### PR DESCRIPTION
… descriptor/Pipes cleanup.

1. Basic Management timeout issue surfaced when testing with DLNA CTT that checks if DMS is sending events for the same property with an interval of atleast 0.2 seconds.
2. After creating saync pipes, they were left open and not cleaned up properly. This created "Too many files open" issue.
   ls -l /proc/$(pidof rygel)/fd | wc -l   : command was used to check the number of open fd after each basic management test is executed. This number kept increasing.